### PR TITLE
bug fix on server creation and listing page

### DIFF
--- a/management/models.py
+++ b/management/models.py
@@ -272,4 +272,4 @@ class Server(models.Model):
     server_key = models.CharField(max_length=32, default=generate_key_256) #generate random 256-bit identifier
 
     def __str__(self):
-        return '{}: {}'.format(self.name, self.identifier)
+        return '{}: {}'.format(self.name, self.server_key)


### PR DESCRIPTION
Hello author, there was a bug in this code. when there is already a created server object if you try to access the server listing page from the admin portal there was an error. That's because the listing is trying to access the identifier attribute as defined in the str function. However, there was no such field in the model. sever_key instead is used as identified field.